### PR TITLE
Skip deprecated `temperature` for `claude-opus-4-7` to fix Opus 4.7 failures

### DIFF
--- a/ai_podcast_pipeline_for_cursor.py
+++ b/ai_podcast_pipeline_for_cursor.py
@@ -2331,6 +2331,9 @@ def call_anthropic_model(prompt, model="claude-3-sonnet", temperature=0.8, web_s
                 f"{CLAUDE_OPUS47_THINKING_EFFORT} effort, "
                 f"{CLAUDE_OPUS47_MAX_TOKENS} max output tokens"
             )
+        elif "claude-opus-4-7" in model_lower:
+            # Anthropic deprecated explicit temperature for Opus 4.7.
+            print(f"ℹ️ Skipping temperature for {model} because this model ignores/deprecates it.")
         elif temperature is not None:
             api_params["temperature"] = temperature
         


### PR DESCRIPTION
### Motivation
- GitHub Actions runs were failing with Anthropic HTTP 400 errors because `claude-opus-4-7` treats the `temperature` parameter as deprecated; the pipeline must avoid sending it and remain functional whether web search is enabled or not.

### Description
- Updated `call_anthropic_model` to omit the `temperature` field when the selected model contains `claude-opus-4-7` and added an informational log line `ℹ️ Skipping temperature for ...` to make the behavior visible in workflow logs.

### Testing
- Ran `python -m py_compile ai_podcast_pipeline_for_cursor.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1462b6110832580ef4f44996f2c00)